### PR TITLE
Ruby 3 Compability update to exec_query

### DIFF
--- a/lib/active_record_query_counter.rb
+++ b/lib/active_record_query_counter.rb
@@ -132,7 +132,7 @@ module ActiveRecordQueryCounter
 
   # Module to prepend to the connection adapter to inject the counting behavior.
   module ConnectionAdapterExtension
-    def exec_query(*args)
+    def exec_query(*args, **kwargs)
       start_time = Time.now
       result = super
       if result.is_a?(ActiveRecord::Result)


### PR DESCRIPTION
Ruby 3 requires that the kwargs are split out.

https://github.com/rails/rails/blob/4eeca2af40c0853a9909414d6db3c44780d021f7/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L123