### PR TITLE
Use monotonic time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Calculate elapsed time using monotonic time rather than wall clock time.
+
 ## 1.1.2
 
 ### Added

--- a/lib/active_record_query_counter.rb
+++ b/lib/active_record_query_counter.rb
@@ -133,10 +133,11 @@ module ActiveRecordQueryCounter
   # Module to prepend to the connection adapter to inject the counting behavior.
   module ConnectionAdapterExtension
     def exec_query(*args, **kwargs)
-      start_time = Time.now
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       result = super
       if result.is_a?(ActiveRecord::Result)
-        ActiveRecordQueryCounter.increment(result.length, Time.now - start_time)
+        elapsed_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+        ActiveRecordQueryCounter.increment(result.length, elapsed_time)
       end
       result
     end


### PR DESCRIPTION
Use monotonic time to make elapsed time consistently accurate.